### PR TITLE
Fix namespaces and add player model

### DIFF
--- a/api/.github/workflows/dotnet.yml
+++ b/api/.github/workflows/dotnet.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           dotnet-version: '8.0.x'
       - name: Restore
-        run: dotnet restore api/NextPlay.Api.csproj
+        run: dotnet restore api/api.csproj
       - name: Build
-        run: dotnet build --no-restore api/NextPlay.Api.csproj
+        run: dotnet build --no-restore api/api.csproj
       - name: Test
         run: dotnet test --no-build --verbosity normal
         continue-on-error: true

--- a/api/Controllers/AuthController.cs
+++ b/api/Controllers/AuthController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
-using NextPlay.Models;
+using api.Models;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;

--- a/api/Controllers/PlayersController.cs
+++ b/api/Controllers/PlayersController.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
-using NextPlay.Models;
+using api.Models;
 
 namespace api.Controllers
 {

--- a/api/Controllers/SessionsController.cs
+++ b/api/Controllers/SessionsController.cs
@@ -2,10 +2,10 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using NextPlay.Data;
-using NextPlay.Models;
+using api.Data;
+using api.Models;
 
-namespace NextPlay.Controllers
+namespace api.Controllers
 {
     [ApiController]
     [Route("api/[controller]")]

--- a/api/Data/AppDbContext.cs
+++ b/api/Data/AppDbContext.cs
@@ -1,0 +1,46 @@
+using Microsoft.EntityFrameworkCore;
+using api.Models;
+
+namespace api.Data
+{
+    public class AppDbContext : DbContext
+    {
+        public AppDbContext(DbContextOptions<AppDbContext> options)
+            : base(options)
+        {
+        }
+
+        public DbSet<Player> Players => Set<Player>();
+        public DbSet<Session> Sessions => Set<Session>();
+        public DbSet<Report> Reports => Set<Report>();
+        public DbSet<PlayerSession> PlayerSessions => Set<PlayerSession>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<PlayerSession>()
+                .HasKey(ps => new { ps.PlayerId, ps.SessionId });
+
+            modelBuilder.Entity<PlayerSession>()
+                .HasOne(ps => ps.Player)
+                .WithMany()
+                .HasForeignKey(ps => ps.PlayerId);
+
+            modelBuilder.Entity<PlayerSession>()
+                .HasOne(ps => ps.Session)
+                .WithMany()
+                .HasForeignKey(ps => ps.SessionId);
+        }
+    }
+
+    public class PlayerSession
+    {
+        public string PlayerId { get; set; } = string.Empty;
+        public Player? Player { get; set; }
+
+        public int SessionId { get; set; }
+        public Session? Session { get; set; }
+    }
+}
+

--- a/api/Data/ApplicationDbContext.cs
+++ b/api/Data/ApplicationDbContext.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
-using NextPlay.Models;
+using api.Models;
 
 namespace api.Data
 {
@@ -15,3 +15,4 @@ namespace api.Data
         public DbSet<Report> Reports => Set<Report>();
     }
 }
+

--- a/api/Models/ApplicationUser.cs
+++ b/api/Models/ApplicationUser.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using System.ComponentModel.DataAnnotations;
 
-namespace NextPlay.Models
+namespace api.Models
 {
     public class ApplicationUser : IdentityUser
     {

--- a/api/Models/Coach.cs
+++ b/api/Models/Coach.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.Models
+{
+    public class Coach
+    {
+        [Key]
+        public string Id { get; set; } = string.Empty;
+
+        public ICollection<Session> Sessions { get; set; } = new List<Session>();
+    }
+}
+

--- a/api/Models/Player.cs
+++ b/api/Models/Player.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace api.Models
+{
+    public class Player
+    {
+        [Key]
+        public string Id { get; set; } = string.Empty;
+
+        [ForeignKey(nameof(Id))]
+        public ApplicationUser? User { get; set; }
+
+        public ICollection<PlayerSession> PlayerSessions { get; set; } = new List<PlayerSession>();
+    }
+}
+

--- a/api/Models/Report.cs
+++ b/api/Models/Report.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace NextPlay.Models
+namespace api.Models
 {
     public class Report
     {

--- a/api/Models/Session.cs
+++ b/api/Models/Session.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
-namespace NextPlay.Models
+namespace api.Models
 {
     public class Session
     {

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -4,8 +4,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using System.Text;
-using NextPlay.Data;
-using NextPlay.Models;
+using api.Data;
+using api.Models;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -92,3 +92,4 @@ app.UseAuthorization();
 app.MapControllers();
 
 app.Run();
+

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.8" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.3" />
   </ItemGroup>
 
 </Project>

--- a/api/railway.json
+++ b/api/railway.json
@@ -5,7 +5,7 @@
       "publishDirectory": "out"
     },
     "deploy": {
-      "startCommand": "dotnet NextPlay.Api.dll",
+      "startCommand": "dotnet api.dll",
       "restartPolicyType": "ALWAYS"
     }
   }


### PR DESCRIPTION
## Summary
- fix inconsistent namespaces across the API project
- add missing `Player` and `Coach` models
- configure EF Core packages and update workflow/railway settings
- adjust controllers and Program to use `api` namespace

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685162e90acc832bb006187db922cb45