### PR TITLE
Add BCrypt password helper

### DIFF
--- a/api/Helpers/PasswordHelper.cs
+++ b/api/Helpers/PasswordHelper.cs
@@ -1,0 +1,17 @@
+using BCrypt.Net;
+
+namespace api.Helpers
+{
+    public static class PasswordHelper
+    {
+        public static string HashPassword(string password)
+        {
+            return BCrypt.HashPassword(password);
+        }
+
+        public static bool VerifyPassword(string password, string hashedPassword)
+        {
+            return BCrypt.Verify(password, hashedPassword);
+        }
+    }
+}

--- a/api/api.csproj
+++ b/api/api.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.3" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.12.1" />
+    <PackageReference Include="BCrypt.Net-Next" Version="4.0.2" />
   </ItemGroup>
 
 </Project>

--- a/api/appsettings.json
+++ b/api/appsettings.json
@@ -5,5 +5,10 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Jwt": {
+    "Key": "SuperSecretKey12345",
+    "Issuer": "nextplay.api",
+    "Audience": "nextplay.client"
+  }
 }


### PR DESCRIPTION
## Summary
- add BCrypt.Net-Next dependency
- implement `PasswordHelper` with methods for hashing and verification
- configure JWT settings

## Testing
- `dotnet build api/api.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac5137810832bb6f1472e3f405ecb