### PR TITLE
Add team/club/invite support

### DIFF
--- a/api/Controllers/AuthController.cs
+++ b/api/Controllers/AuthController.cs
@@ -32,7 +32,8 @@ namespace api.Controllers
                 FullName = dto.FullName,
                 Position = dto.Position,
                 Team = dto.Team,
-                DateOfBirth = dto.DateOfBirth
+                DateOfBirth = dto.DateOfBirth,
+                Role = dto.Role
             };
 
             var result = await _userManager.CreateAsync(user, dto.Password);

--- a/api/Controllers/ClubsController.cs
+++ b/api/Controllers/ClubsController.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using api.Models;
+using api.Services;
+
+namespace api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize(Policy = "AdminPolicy")]
+    public class ClubsController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly ClubService _clubService;
+
+        public ClubsController(UserManager<ApplicationUser> userManager, ClubService clubService)
+        {
+            _userManager = userManager;
+            _clubService = clubService;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateClub([FromBody] Club club)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return Unauthorized(new ApiResponse<object>(false, "Unauthorized"));
+            club.CreatedByAdminId = user.Id;
+            var created = await _clubService.CreateClubAsync(club);
+            return CreatedAtAction(nameof(GetClubs), new { id = created.Id }, new ApiResponse<Club>(true, null, created));
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetClubs()
+        {
+            var clubs = await _clubService.GetClubsAsync();
+            return Ok(new ApiResponse<IEnumerable<Club>>(true, null, clubs));
+        }
+    }
+}

--- a/api/Controllers/InvitesController.cs
+++ b/api/Controllers/InvitesController.cs
@@ -1,0 +1,50 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using api.Models;
+using api.Services;
+
+namespace api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class InvitesController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly InviteService _inviteService;
+
+        public InvitesController(UserManager<ApplicationUser> userManager, InviteService inviteService)
+        {
+            _userManager = userManager;
+            _inviteService = inviteService;
+        }
+
+        [HttpPost]
+        [Authorize(Roles = "Admin,Coach")]
+        public async Task<IActionResult> CreateInvite([FromBody] Invite invite)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return Unauthorized(new ApiResponse<object>(false, "Unauthorized"));
+            var roles = await _userManager.GetRolesAsync(user);
+            if (roles.Contains("Coach"))
+            {
+                invite.TeamId = user.TeamId;
+            }
+            else if (roles.Contains("Admin"))
+            {
+                invite.ClubId = user.ClubId;
+            }
+            var created = await _inviteService.CreateInviteAsync(invite);
+            return Ok(new ApiResponse<Invite>(true, null, created));
+        }
+
+        [HttpPost("accept/{token}")]
+        public async Task<IActionResult> AcceptInvite(string token)
+        {
+            var invite = await _inviteService.GetInviteByTokenAsync(token);
+            if (invite == null) return NotFound(new ApiResponse<object>(false, "Invalid invite"));
+            await _inviteService.AcceptInviteAsync(invite);
+            return Ok(new ApiResponse<object>(true, "Invite accepted"));
+        }
+    }
+}

--- a/api/Controllers/PlayersController.cs
+++ b/api/Controllers/PlayersController.cs
@@ -24,7 +24,9 @@ namespace api.Controllers
         [Authorize(Policy = "CoachPolicy")]
         public async Task<IActionResult> GetPlayers()
         {
-            var players = await _playerService.GetPlayersAsync();
+            var requester = await _userManager.GetUserAsync(User);
+            if (requester == null) return Unauthorized(new ApiResponse<object>(false, "Unauthorized"));
+            var players = await _playerService.GetPlayersAsync(requester);
             var data = players.Select(u => new { u.Id, u.FullName, u.Email });
             return Ok(new ApiResponse<object>(true, null, data));
         }

--- a/api/Controllers/TeamsController.cs
+++ b/api/Controllers/TeamsController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using api.Models;
+using api.Services;
+
+namespace api.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class TeamsController : ControllerBase
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly TeamService _teamService;
+
+        public TeamsController(UserManager<ApplicationUser> userManager, TeamService teamService)
+        {
+            _userManager = userManager;
+            _teamService = teamService;
+        }
+
+        [HttpPost]
+        [Authorize(Policy = "AdminPolicy")]
+        public async Task<IActionResult> CreateTeam([FromBody] Team team)
+        {
+            var created = await _teamService.CreateTeamAsync(team);
+            return CreatedAtAction(nameof(GetTeam), new { id = created.Id }, new ApiResponse<Team>(true, null, created));
+        }
+
+        [HttpGet("{id}")]
+        [Authorize]
+        public async Task<IActionResult> GetTeam(int id)
+        {
+            var team = await _teamService.GetTeamAsync(id);
+            if (team == null) return NotFound(new ApiResponse<object>(false, "Not found"));
+            return Ok(new ApiResponse<Team>(true, null, team));
+        }
+    }
+}

--- a/api/Data/AppDbContext .cs
+++ b/api/Data/AppDbContext .cs
@@ -15,6 +15,9 @@ namespace api.Data
         public DbSet<PlayerSession> PlayerSessions { get; set; } = default!;
         public DbSet<Session> Sessions { get; set; } = default!;
         public DbSet<Report> Reports { get; set; } = default!;
+        public DbSet<Club> Clubs { get; set; } = default!;
+        public DbSet<Team> Teams { get; set; } = default!;
+        public DbSet<Invite> Invites { get; set; } = default!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
@@ -32,6 +35,41 @@ namespace api.Data
                 .HasOne(ps => ps.Session)
                 .WithMany()
                 .HasForeignKey(ps => ps.SessionId);
+
+            modelBuilder.Entity<Team>()
+                .HasOne(t => t.Club)
+                .WithMany(c => c.Teams)
+                .HasForeignKey(t => t.ClubId);
+
+            modelBuilder.Entity<Player>()
+                .HasOne(p => p.Team)
+                .WithMany(t => t.Players)
+                .HasForeignKey(p => p.TeamId);
+
+            modelBuilder.Entity<Session>()
+                .HasOne(s => s.Team)
+                .WithMany()
+                .HasForeignKey(s => s.TeamId);
+
+            modelBuilder.Entity<Invite>()
+                .HasOne(i => i.Club)
+                .WithMany()
+                .HasForeignKey(i => i.ClubId);
+
+            modelBuilder.Entity<Invite>()
+                .HasOne(i => i.Team)
+                .WithMany()
+                .HasForeignKey(i => i.TeamId);
+
+            modelBuilder.Entity<ApplicationUser>()
+                .HasOne(u => u.TeamEntity)
+                .WithMany()
+                .HasForeignKey(u => u.TeamId);
+
+            modelBuilder.Entity<ApplicationUser>()
+                .HasOne(u => u.Club)
+                .WithMany()
+                .HasForeignKey(u => u.ClubId);
         }
     }
 }

--- a/api/Models/ApplicationUser.cs
+++ b/api/Models/ApplicationUser.cs
@@ -11,5 +11,15 @@ namespace api.Models
         public string? Position { get; set; }
         public string? Team { get; set; }
         public DateTime? DateOfBirth { get; set; }
+
+        // Role is stored both in Identity and here for convenience for the frontend
+        public string Role { get; set; } = string.Empty;
+
+        // Relations to club and team (nullable as not all users belong to one)
+        public int? ClubId { get; set; }
+        public Club? Club { get; set; }
+
+        public int? TeamId { get; set; }
+        public Team? TeamEntity { get; set; }
     }
 }

--- a/api/Models/Club.cs
+++ b/api/Models/Club.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.Models
+{
+    public class Club
+    {
+        public int Id { get; set; }
+        [Required]
+        public string Name { get; set; } = string.Empty;
+        public string? CreatedByAdminId { get; set; }
+        public ApplicationUser? CreatedByAdmin { get; set; }
+        public bool IsSubscribed { get; set; } = false;
+        public ICollection<Team> Teams { get; set; } = new List<Team>();
+    }
+}

--- a/api/Models/Coach.cs
+++ b/api/Models/Coach.cs
@@ -7,6 +7,9 @@ namespace api.Models
         [Key]
         public string Id { get; set; } = string.Empty;
 
+        public int? TeamId { get; set; }
+        public Team? Team { get; set; }
+
         public ICollection<Session> Sessions { get; set; } = new List<Session>();
     }
 }

--- a/api/Models/Invite.cs
+++ b/api/Models/Invite.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.Models
+{
+    public class Invite
+    {
+        public int Id { get; set; }
+        [Required, EmailAddress]
+        public string Email { get; set; } = string.Empty;
+        [Required]
+        public string Role { get; set; } = string.Empty;
+        public int? ClubId { get; set; }
+        public Club? Club { get; set; }
+        public int? TeamId { get; set; }
+        public Team? Team { get; set; }
+        public string Token { get; set; } = Guid.NewGuid().ToString();
+        public bool IsAccepted { get; set; } = false;
+    }
+}

--- a/api/Models/Player.cs
+++ b/api/Models/Player.cs
@@ -11,6 +11,9 @@ namespace api.Models
         [ForeignKey(nameof(Id))]
         public ApplicationUser? User { get; set; }
 
+        public int? TeamId { get; set; }
+        public Team? Team { get; set; }
+
         public ICollection<PlayerSession> PlayerSessions { get; set; } = new List<PlayerSession>();
         
 

--- a/api/Models/Session.cs
+++ b/api/Models/Session.cs
@@ -11,6 +11,9 @@ namespace api.Models
         public DateTime Date { get; set; }
         public string? Location { get; set; }
         public int Intensity { get; set; }
+
+        public int? TeamId { get; set; }
+        public Team? Team { get; set; }
         [Required]
         public string CoachId { get; set; } = string.Empty;
         [ForeignKey(nameof(CoachId))]

--- a/api/Models/Team.cs
+++ b/api/Models/Team.cs
@@ -1,0 +1,14 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace api.Models
+{
+    public class Team
+    {
+        public int Id { get; set; }
+        [Required]
+        public string Name { get; set; } = string.Empty;
+        public int ClubId { get; set; }
+        public Club? Club { get; set; }
+        public ICollection<Player> Players { get; set; } = new List<Player>();
+    }
+}

--- a/api/Program.cs
+++ b/api/Program.cs
@@ -63,6 +63,9 @@ builder.Services.AddScoped<AuthService>();
 builder.Services.AddScoped<ReportService>();
 builder.Services.AddScoped<SessionService>();
 builder.Services.AddScoped<PlayerService>();
+builder.Services.AddScoped<ClubService>();
+builder.Services.AddScoped<TeamService>();
+builder.Services.AddScoped<InviteService>();
 
 // Rate limiting
 builder.Services.AddRateLimiter(options =>

--- a/api/Services/ClubService.cs
+++ b/api/Services/ClubService.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using api.Data;
+using api.Models;
+
+namespace api.Services;
+
+public class ClubService
+{
+    private readonly AppDbContext _db;
+
+    public ClubService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Club> CreateClubAsync(Club club)
+    {
+        _db.Clubs.Add(club);
+        await _db.SaveChangesAsync();
+        return club;
+    }
+
+    public async Task<IEnumerable<Club>> GetClubsAsync()
+    {
+        return await _db.Clubs.Include(c => c.Teams).ToListAsync();
+    }
+
+    public async Task<Club?> GetClubAsync(int id)
+    {
+        return await _db.Clubs.Include(c => c.Teams).FirstOrDefaultAsync(c => c.Id == id);
+    }
+}

--- a/api/Services/InviteService.cs
+++ b/api/Services/InviteService.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using api.Data;
+using api.Models;
+
+namespace api.Services;
+
+public class InviteService
+{
+    private readonly AppDbContext _db;
+
+    public InviteService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Invite> CreateInviteAsync(Invite invite)
+    {
+        _db.Invites.Add(invite);
+        await _db.SaveChangesAsync();
+        return invite;
+    }
+
+    public async Task<Invite?> GetInviteByTokenAsync(string token)
+    {
+        return await _db.Invites.FirstOrDefaultAsync(i => i.Token == token && !i.IsAccepted);
+    }
+
+    public async Task AcceptInviteAsync(Invite invite)
+    {
+        invite.IsAccepted = true;
+        await _db.SaveChangesAsync();
+    }
+}

--- a/api/Services/PlayerService.cs
+++ b/api/Services/PlayerService.cs
@@ -12,9 +12,15 @@ public class PlayerService
         _userManager = userManager;
     }
 
-    public async Task<IEnumerable<ApplicationUser>> GetPlayersAsync()
+    public async Task<IEnumerable<ApplicationUser>> GetPlayersAsync(ApplicationUser requester)
     {
-        return await _userManager.GetUsersInRoleAsync("Player");
+        var players = await _userManager.GetUsersInRoleAsync("Player");
+        var roles = await _userManager.GetRolesAsync(requester);
+        if (roles.Contains("Coach") && !roles.Contains("Admin"))
+        {
+            players = players.Where(p => p.TeamId == requester.TeamId).ToList();
+        }
+        return players;
     }
 
     public async Task<ApplicationUser?> GetPlayerAsync(string id)

--- a/api/Services/ReportService.cs
+++ b/api/Services/ReportService.cs
@@ -27,7 +27,7 @@ public class ReportService
         }
         else if (roles.Contains("Coach") && !roles.Contains("Admin"))
         {
-            query = query.Where(r => r.Session!.CoachId == user.Id);
+            query = query.Where(r => r.Session!.CoachId == user.Id && r.Session!.TeamId == user.TeamId);
         }
 
         return await query.ToListAsync();
@@ -44,7 +44,7 @@ public class ReportService
         }
         else if (roles.Contains("Coach") && !roles.Contains("Admin"))
         {
-            query = query.Where(r => r.Session!.CoachId == user.Id);
+            query = query.Where(r => r.Session!.CoachId == user.Id && r.Session!.TeamId == user.TeamId);
         }
 
         return await query.FirstOrDefaultAsync(r => r.Id == id);

--- a/api/Services/SessionService.cs
+++ b/api/Services/SessionService.cs
@@ -27,7 +27,7 @@ public class SessionService
         }
         else if (roles.Contains("Coach") && !roles.Contains("Admin"))
         {
-            query = query.Where(s => s.CoachId == user.Id);
+            query = query.Where(s => s.CoachId == user.Id && s.TeamId == user.TeamId);
         }
 
         return await query.ToListAsync();
@@ -44,7 +44,7 @@ public class SessionService
         }
         else if (roles.Contains("Coach") && !roles.Contains("Admin"))
         {
-            query = query.Where(s => s.CoachId == user.Id);
+            query = query.Where(s => s.CoachId == user.Id && s.TeamId == user.TeamId);
         }
 
         return await query.FirstOrDefaultAsync(s => s.Id == id);

--- a/api/Services/TeamService.cs
+++ b/api/Services/TeamService.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore;
+using api.Data;
+using api.Models;
+
+namespace api.Services;
+
+public class TeamService
+{
+    private readonly AppDbContext _db;
+
+    public TeamService(AppDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Team> CreateTeamAsync(Team team)
+    {
+        _db.Teams.Add(team);
+        await _db.SaveChangesAsync();
+        return team;
+    }
+
+    public async Task<IEnumerable<Team>> GetTeamsAsync(int clubId)
+    {
+        return await _db.Teams.Where(t => t.ClubId == clubId).Include(t => t.Players).ToListAsync();
+    }
+
+    public async Task<Team?> GetTeamAsync(int id)
+    {
+        return await _db.Teams.Include(t => t.Players).FirstOrDefaultAsync(t => t.Id == id);
+    }
+}


### PR DESCRIPTION
## Summary
- add Club, Team and Invite entities
- wire up EF DbContext relationships
- add services for clubs, teams and invites
- secure session and report queries by team
- expose new controllers for clubs, teams and invites
- register new services in Program
- extend ApplicationUser and Auth registration with role and relation fields

## Testing
- `dotnet build api/api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c5ccd6d00832b9e2f21c85794197d